### PR TITLE
Use = instead of == for condition evaluation utility

### DIFF
--- a/tools/build_isupam.sh
+++ b/tools/build_isupam.sh
@@ -2,7 +2,7 @@
 OS_TARGETS="linux darwin freebsd windows"
 
 for os in $OS_TARGETS; do
-  if [ "$os" == "windows" ]; then
+  if [ "$os" = "windows" ]; then
     GOOS=$os go build -ldflags "-s -w" -o bin/isupam_$os.exe ./cmd/isupam
   else
     GOOS=$os go build -ldflags "-s -w" -o bin/isupam_$os ./cmd/isupam


### PR DESCRIPTION
[ ]内での文字列比較は`==`ではなく`=`ですね。
`unexpected operator`のメッセージと共に`[`コマンドが失敗するため、windowsの実行ファイルにも.exeが付与されませんでした。
