### PR TITLE
Remove --disable-phar to install composer

### DIFF
--- a/provisioning/image/ansible/02_xbuild.yml
+++ b/provisioning/image/ansible/02_xbuild.yml
@@ -27,7 +27,7 @@
       args:
         creates: /home/isucon/.local/go/bin/go
     # php
-    - command: /home/isucon/.xbuild/php-install 7.0.10 /home/isucon/.local/php -- --disable-phar --with-pcre-regex --with-zlib --enable-fpm --enable-pdo --with-mysqli=mysqlnd --with-pdo-mysql=mysqlnd --with-openssl --with-pcre-regex --with-pcre-dir --with-libxml-dir --enable-opcache --enable-bcmath --with-bz2 --enable-calendar --enable-cli --enable-shmop --enable-sysvsem --enable-sysvshm --enable-sysvmsg --enable-mbregex --enable-mbstring --with-mcrypt --enable-pcntl --enable-sockets --with-curl --enable-zip --with-pear
+    - command: /home/isucon/.xbuild/php-install 7.0.10 /home/isucon/.local/php -- --with-pcre-regex --with-zlib --enable-fpm --enable-pdo --with-mysqli=mysqlnd --with-pdo-mysql=mysqlnd --with-openssl --with-pcre-regex --with-pcre-dir --with-libxml-dir --enable-opcache --enable-bcmath --with-bz2 --enable-calendar --enable-cli --enable-shmop --enable-sysvsem --enable-sysvshm --enable-sysvmsg --enable-mbregex --enable-mbstring --with-mcrypt --enable-pcntl --enable-sockets --with-curl --enable-zip --with-pear
       args:
         creates: /home/isucon/.local/php/bin/php
 


### PR DESCRIPTION
phar.soがないためにcomposerのインストールが失敗する問題を回避
