### PR TITLE
Close keep-alived connections

### DIFF
--- a/bench/checker/session.go
+++ b/bench/checker/session.go
@@ -23,16 +23,15 @@ const (
 )
 
 var (
-	targetHost string
-	getTimeout = 15 * time.Second
+	targetHost  string
+	getTimeout  = 15 * time.Second
 	postTimeout = 3 * time.Second
 )
 
 type Session struct {
 	Client    *http.Client
 	Transport *http.Transport
-
-	logger *log.Logger
+	logger    *log.Logger
 }
 
 var RedirectAttemptedError = fmt.Errorf("redirect attempted")
@@ -48,8 +47,8 @@ func NewSession() *Session {
 		Transport: w.Transport,
 		Jar:       jar,
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
-            return RedirectAttemptedError
-        },
+			return RedirectAttemptedError
+		},
 	}
 	return w
 }
@@ -161,11 +160,15 @@ func (s *Session) NewFileUploadRequest(uri string, params map[string]string, par
 
 func (s *Session) RefreshClient() {
 	jar, _ := cookiejar.New(&cookiejar.Options{})
-	s.Transport = &http.Transport{}
+	s.Transport.CloseIdleConnections()
 	s.Client = &http.Client{
 		Transport: s.Transport,
 		Jar:       jar,
 	}
+}
+
+func (s *Session) CloseConns() {
+	s.Transport.CloseIdleConnections()
 }
 
 func (s *Session) SendRequest(req *http.Request) (*http.Response, error) {

--- a/bench/cli.go
+++ b/bench/cli.go
@@ -67,7 +67,9 @@ func (sr *scenarioRunner) start(ch chan *scenarioRunner) {
 }
 func (sr *scenarioRunner) run() {
 	for _, fn := range sr.scenarios {
-		fn(checker.NewSession(), sr.bdata)
+		s := checker.NewSession()
+		fn(s, sr.bdata)
+		s.CloseConns()
 	}
 	sr.done <- struct{}{}
 }
@@ -183,7 +185,9 @@ func start(bdata *benchdata) bool {
 	for _, fn := range initialScenarios {
 		go func(fn scenarioFn) {
 			defer wg.Done()
-			fn(checker.NewSession(), bdata)
+			s := checker.NewSession()
+			fn(s, bdata)
+			s.CloseConns()
 		}(fn)
 	}
 	wg.Wait()
@@ -193,7 +197,7 @@ func start(bdata *benchdata) bool {
 		score.GetInstance().SetFails(0)
 		score.GetFailErrorsInstance().Append(fmt.Errorf("初期チェックがタイムアウトしました"))
 	}
-	if (score.GetInstance().GetFails() - score.GetInstance().GetTimeouts()) > 0  {
+	if (score.GetInstance().GetFails() - score.GetInstance().GetTimeouts()) > 0 {
 		return false
 	}
 	log.Println("pre-check finished and start main benchmarking")


### PR DESCRIPTION
fixes #3 

Client ごとに Transport を作り直す方式による修正です。
（go fmt の結果無関係な所まで変更が入ってますがご容赦ください）
